### PR TITLE
fix(vt-2026-3854): stop long PoC one-liner from breaking the detail page

### DIFF
--- a/cves/vt-2026-3854/index.yaml
+++ b/cves/vt-2026-3854/index.yaml
@@ -4,6 +4,12 @@ info:
   name: "GitHub Enterprise Server - X-Stat Field Injection to Pre-Receive Hook RCE"
   author: omarkurt
   description: |
+    ⚠️  NOTE: This is a SIMULATED vulnerability environment using Python/Flask.
+    The actual GitHub Enterprise Server (babeld / pre-receive binaries) is NOT
+    included — GHES is closed-source commercial software and cannot be
+    redistributed. The lab emulates the exact vulnerable X-Stat parsing and
+    hook-resolution behavior described in the advisory for educational purposes.
+
     GitHub Enterprise Server versions up to and including 3.19.1 are affected
     by a remote code execution vulnerability (CVE-2026-3854) in the internal
     git protocol. babeld copies git push-option values directly into the
@@ -14,11 +20,7 @@ info:
     hook sandbox and redirect hook resolution to an attacker-controlled,
     path-traversed location, resulting in arbitrary command execution as the
     git service user via a single `git push -o` command. GitHub.com was also
-    affected and was patched within 6 hours of report. This package ships a
-    simulated HTTP lab: GHES is closed-source commercial software, so the
-    real babeld / pre-receive binaries cannot be obtained or redistributed.
-    The lab reproduces the exact vulnerable parsing and hook-resolution
-    logic described in the advisory over a small Flask harness.
+    affected and was patched within 6 hours of report.
   type: CVE
   targets:
     - github-enterprise-server
@@ -161,8 +163,8 @@ post-install:
   - "docker compose up -d"
   - "Wait for the healthcheck to pass (a few seconds)"
   - "Banner: curl http://localhost:8385/"
-  - "Auth token (simulated push credential): demo-user-push-token-123 -- required on every /internal/git-receive call, else 401"
-  - "Baseline (safe, no injection): curl -X POST http://localhost:8385/internal/git-receive -H 'Content-Type: application/json' -H 'Authorization: Bearer demo-user-push-token-123' -d '{\"push_options\":[\"id=abc123\"]}'"
-  - "Exploit: curl -X POST http://localhost:8385/internal/git-receive -H 'Content-Type: application/json' -H 'Authorization: Bearer demo-user-push-token-123' -d '{\"push_options\":[\"id=abc123;rails_env=development;custom_hooks_dir=/tmp/evil;repo_pre_receive_hooks=pwn.sh\"],\"hook_payload\":\"IyEvYmluL3NoCmVjaG8gVlRfMjAyNl8zODU0X1BXTkVEXyQoaWQgLXUpXyQod2hvYW1pKQo=\"}'"
-  - "Path traversal alone (no custom_hooks_dir): repo_pre_receive_hooks=../../../tmp/x.sh escapes /srv/hooks/safe entirely"
+  - "Auth: every POST /internal/git-receive needs header 'Authorization: Bearer demo-user-push-token-123', otherwise 401"
+  - "Baseline (no injection): POST /internal/git-receive with push_options ['id=abc123'] -> sandboxed:true, executed:false"
+  - "Exploit: put ';rails_env=development;custom_hooks_dir=/tmp/evil;repo_pre_receive_hooks=pwn.sh' inside one push option, plus a base64 hook_payload -> sandboxed:false, executed:true (full request: see the Exploit Chain above and the nuclei PoC)"
+  - "Path traversal alone: repo_pre_receive_hooks=../../../tmp/x.sh escapes /srv/hooks/safe"
   - "nuclei -t vt-2026-3854.nuclei.yaml -u http://localhost:8385"


### PR DESCRIPTION
The post-install "Exploit" step embedded a ~400-char curl one-liner (escaped JSON + base64 hook payload) as a single unbreakable token. vt-site renders post-install items in .post-install-list without word-break, so that token overflowed the container and broke the detail page layout (vulnerabletarget.com/detail.html?id=vt-2026-3854).

Rewrites the Baseline/Exploit steps to concise, page-safe text that references the full request already shown in the Exploit Chain and the nuclei PoC. Also re-adds the standard "⚠️ SIMULATED environment" notice to the description (convention: cves/vt-2026-21962), which was missing on main.